### PR TITLE
Test: Add sad path test for user registration, and add error messages

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,8 +7,8 @@ class UsersController < ApplicationController
     if user.save
       redirect_to "/users/#{user.id}"
     else
-      flash[:notice] = "Please enter a valid name and email address to register."
       redirect_to "/register"
+      flash[:notice] = user.errors.full_messages.last
     end
   end
 

--- a/spec/features/register_spec.rb
+++ b/spec/features/register_spec.rb
@@ -30,16 +30,78 @@ RSpec.describe "User Registration Page", type: :feature do
     expect(page).to_not have_content('Please enter a valid name and email address to register.')
   end
 
-  # it 'will not register an email that was already used' do
-  #   visit "/register"
-  #
-  #   fill_in :name, with: 'Sai Again'
-  #   fill_in :email, with: 'SaiLent@overlord.com'
-  #   fill_in :password, with: 'LetMeIn'
-  #   fill_in :password_confirmation, with: 'LetMeIn'
-  #   click_button("Register")
-  #
-  #   expect(page).to have_current_path('/register')
-  #   expect(page).to have_content('Please enter a valid name and email address to register.')
-  # end
+  it 'will not register an email that was already used' do
+    visit "/register"
+    user1 = User.create!(name: 'Sai', email: 'SaiLent@overlord.com', password: 'no-u', password_confirmation: 'no-u')
+
+    fill_in :name, with: 'Sai Again'
+    fill_in :email, with: 'SaiLent@overlord.com'
+    fill_in :password, with: 'LetMeIn'
+    fill_in :password_confirmation, with: 'LetMeIn'
+    click_button("Register")
+
+    expect(page).to have_current_path('/register')
+    expect(page).to have_content("Email has already been taken")
+  end
+
+  it 'will not register a user if the password and confirmation do not match' do
+    visit "/register"
+
+    fill_in :name, with: 'Sai Again'
+    fill_in :email, with: 'SaiLent@overlord.com'
+    fill_in :password, with: 'LetMeIn'
+    fill_in :password_confirmation, with: 'PleaseLetMeIn'
+    click_button("Register")
+
+    expect(page).to have_current_path('/register')
+    expect(page).to have_content("Password confirmation doesn't match Password")
+  end
+
+  it 'will not register a user if the password is empty' do
+    visit "/register"
+
+    fill_in :name, with: 'Sai Again'
+    fill_in :email, with: 'SaiLent@overlord.com'
+    fill_in :password_confirmation, with: 'LetMeIn'
+    click_button("Register")
+
+    expect(page).to have_current_path('/register')
+    expect(page).to have_content("Password can't be blank")
+  end
+
+  it 'will not register a user if the name is empty' do
+    visit "/register"
+
+    fill_in :email, with: 'SaiLent@overlord.com'
+    fill_in :password, with: 'LetMeIn'
+    fill_in :password_confirmation, with: 'LetMeIn'
+    click_button("Register")
+
+    expect(page).to have_current_path('/register')
+    expect(page).to have_content("Name can't be blank")
+  end
+
+  it 'will not register a user if the email is empty' do
+    visit "/register"
+
+    fill_in :name, with: 'Sai Again'
+    fill_in :password, with: 'LetMeIn'
+    fill_in :password_confirmation, with: 'LetMeIn'
+    click_button("Register")
+
+    expect(page).to have_current_path('/register')
+    expect(page).to have_content("Email can't be blank")
+  end
+
+  it 'will not register a user if the password confirmation is empty' do
+    visit "/register"
+
+    fill_in :name, with: 'Sai Again'
+    fill_in :email, with: 'SaiLent@overlord.com'
+    fill_in :password, with: 'LetMeIn'
+    click_button("Register")
+
+    expect(page).to have_current_path('/register')
+    expect(page).to have_content("Password confirmation doesn't match Password")
+  end
 end


### PR DESCRIPTION
Added sad path testing, per user story 2. All tests passing, error messages enabled for user registration
